### PR TITLE
Reset _configCache for Mage::app()->getStore()

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Fixture/Processor/Config.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Fixture/Processor/Config.php
@@ -77,6 +77,10 @@ class EcomDev_PHPUnit_Model_Fixture_Processor_Config
                 $store, '_configCache', array()
             );
         }
+        $store = Mage::app()->getStore();
+        EcomDev_Utils_Reflection::setRestrictedPropertyValue(
+            $store, '_configCache', array()
+        );
         return $this;
     }
 
@@ -151,6 +155,10 @@ class EcomDev_PHPUnit_Model_Fixture_Processor_Config
             $store, '_configCache', array()
             );
         }
+        $store = Mage::app()->getStore();
+        EcomDev_Utils_Reflection::setRestrictedPropertyValue(
+            $store, '_configCache', array()
+        );
         
         return $this;
     }


### PR DESCRIPTION
Reset _configCache for Mage::app()->getStore() because it might not by in Mage::app()->getStores(true).

Mage::app()->getStore() might get it's store from _currentStore, which is sometimes an object that is sometimes not retrieved through Mage::app()->getStores(true).